### PR TITLE
Use `postgres-client` instead of `postgres`

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,7 +2,7 @@ ARG PY_VERSION=3.11
 
 FROM gitpod/workspace-python-${PY_VERSION}:latest
 
-RUN sudo apt-get update && sudo apt-get -y install postgresql
+RUN sudo apt-get update && sudo apt-get -y install postgresql-client
 RUN pip install "poetry==1.3.2"
 
 COPY poetry.lock pyproject.toml /


### PR DESCRIPTION
Overlooked this in the review, but we should use the lighter `postgres-client` (which installs _just_ `psql`).